### PR TITLE
Icons working. Must include far fas or fab in class.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 gem 'devise'
 
 gem 'autoprefixer-rails', '10.2.5'
-gem 'font-awesome-sass', '~> 5.6.1'
+gem 'font-awesome-sass', '~> 6.1', '>= 6.1.1'
 gem 'simple_form', github: 'heartcombo/simple_form'
 group :development, :test do  gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,8 @@ GEM
     erubi (1.10.0)
     execjs (2.7.0)
     ffi (1.15.5)
-    font-awesome-sass (5.6.1)
-      sassc (>= 1.11)
+    font-awesome-sass (6.1.1)
+      sassc (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.10.0)
@@ -253,7 +253,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   dotenv-rails
-  font-awesome-sass (~> 5.6.1)
+  font-awesome-sass (~> 6.1, >= 6.1.1)
   listen (~> 3.3)
   pg (~> 1.1)
   pry-byebug
@@ -276,4 +276,4 @@ RUBY VERSION
    ruby 3.0.3p157
 
 BUNDLED WITH
-   2.3.16
+   2.3.8

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,7 +5,6 @@
 
 // External libraries
 @import "bootstrap/scss/bootstrap";
-@import "font-awesome-sprockets";
 @import "font-awesome";
 
 // Your CSS partials

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -38,4 +38,3 @@
     </tbody>
   </table>
 </div>
-<i class="fa-thin far fa-face-laugh-beam"></i>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -38,3 +38,4 @@
     </tbody>
   </table>
 </div>
+<i class="fa-thin far fa-face-laugh-beam"></i>


### PR DESCRIPTION
Must include fas, far or fab in class for icon to display.

Ref: https://www.rubydoc.info/gems/font-awesome-sass/6.1.1

![Screen Shot 2022-07-09 at 12 29 08 pm](https://user-images.githubusercontent.com/43901618/178088265-a6e519bd-19b0-43d8-b9b7-a5240d03799b.png)
![Screen Shot 2022-07-09 at 12 29 15 pm](https://user-images.githubusercontent.com/43901618/178088266-304dc23e-495b-4c1b-b9c3-e9af8291c430.png)
