### PR TITLE
Fixed multiple issues.

### DIFF
--- a/app/assets/stylesheets/components/_notification.scss
+++ b/app/assets/stylesheets/components/_notification.scss
@@ -1,6 +1,6 @@
 .notification-icon{
-  padding-top: 14px;
-  font-size: 18pt;
+  padding-top: 15px;
+  font-size: 20pt;
   color: rgb(115, 115, 115);
   margin-right: 23px;
   margin-left: 40px;
@@ -12,6 +12,10 @@
 
 .badge {
   font-size: 8pt;
-  top: 6px;
+  top: 10px;
   left: 65px;
+}
+
+.notification-list:empty {
+  display: none;
 }

--- a/app/views/shared/_notification.html.erb
+++ b/app/views/shared/_notification.html.erb
@@ -1,14 +1,20 @@
 <li class="nav-item dropdown notification-li" role="button">
-  <i class="fas fa-bell dropdown-toggle notification-icon" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
-    <div class="position-absolute translate-middle badge rounded-pill bg-danger">
-    <%=current_user.notifications.unread.length%></div></i>
-  <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-    <% current_user.notifications.unread.each do |notification| %>
-      <% if notification.type == "CommentNotification" %>
-        <%= link_to notification.params[:message], "/items/#{notification.params[:comment].item_id}", class: "dropdown-item" %>
-      <% else  %>
-        <%= link_to notification.params[:message], "/items/#{notification.params[:item].id}", class: "dropdown-item" %>
-      <% end %>
+  <i class="fas fa-bell notification-icon" role="button" id="dropdownMenuLink" data-bs-toggle="dropdown" aria-expanded="false">
+    <% if current_user.notifications.unread.length > 0 %>
+      <div class="position-absolute translate-middle badge rounded-pill bg-danger">
+        <%=current_user.notifications.unread.length%>
+      </div>
     <% end %>
-  </div>
+  </i>
+  <% if current_user.notifications.unread.length > 0 %>
+    <div class="dropdown-menu dropdown-menu-end notification-list" aria-labelledby="navbarDropdown">
+      <% current_user.notifications.unread.each do |notification| %>
+        <% if notification.type == "CommentNotification" %>
+          <%= link_to notification.params[:message], "/items/#{notification.params[:comment].item_id}", class: "dropdown-item" %>
+        <% else  %>
+          <%= link_to notification.params[:message], "/items/#{notification.params[:item].id}", class: "dropdown-item" %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
 </li>


### PR DESCRIPTION
Fixed:
> Issue where red badge displayed even with zero notifications.
> dropdown would display (empty) when zero notifications.
> adjusted size and positioning of bell and notification badge. Removed toggle button from bell for better appearance.

<img width="423" alt="Screen Shot 2022-07-22 at 5 48 52 pm" src="https://user-images.githubusercontent.com/43901618/180391206-698cbfaf-f702-434a-8ac1-310a04a1bacc.png">
<img width="506" alt="Screen Shot 2022-07-22 at 5 49 01 pm" src="https://user-images.githubusercontent.com/43901618/180391216-0a6b1391-eb8c-413d-9bc7-48e5bc3048ea.png">
<img width="443" alt="Screen Shot 2022-07-22 at 5 49 17 pm" src="https://user-images.githubusercontent.com/43901618/180391221-e2c23f5c-da61-4beb-995e-18088bfc4a86.png">
