### PR TITLE
Tided up week cal in dashbord

### DIFF
--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -61,7 +61,7 @@
       </div>
     </div>
     <div class='col-12 px-5 py-4 dash-calendar my-5'>
-      <h2 class='header-txt text-center pb-3'>Upcoming Items</h2>
+      <h2 class='header-txt text-center pb-3'>Items cooling off this week</h2>
       <%= render partial: "dashcalendar", locals: {events: current_user.items} %>
     </div>
     <div class='col-12 my-5 py-4 px-5'>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,5 +1,6 @@
 <div class="simple-calendar">
-  <div class="calendar-heading">
+
+  <!-- <div class="calendar-heading">
     <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
     <% if calendar.number_of_weeks == 1 %>
       <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %></span>
@@ -7,7 +8,7 @@
       <span class="calendar-title"><%= t('simple_calendar.week', default: 'Week') %> <%= calendar.week_number %> - <%= calendar.end_week %></span>
     <% end %>
     <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
-  </div>
+  </div> -->
 
   <table class="table table-striped">
     <thead>
@@ -19,15 +20,11 @@
     </thead>
 
     <tbody>
-      <% date_range.each_slice(7) do |week| %>
+      <% date_range.each_slice(7) do |dates| %>
         <tr>
-          <% week.each do |day| %>
-            <%= content_tag :td, class: calendar.td_classes_for(day) do %>
-              <% if defined?(Haml) && respond_to?(:block_is_haml?) && block_is_haml?(passed_block) %>
-                <% capture_haml(day, sorted_events.fetch(day, []), &passed_block) %>
-              <% else %>
-                <% passed_block.call day, sorted_events.fetch(day, []) %>
-              <% end %>
+          <% dates.each do |date| %>
+            <%= content_tag :td, class: calendar.td_classes_for(date) do %>
+              <% passed_block.call date.day, sorted_events.fetch(date, []) %>
             <% end %>
           <% end %>
         </tr>


### PR DESCRIPTION
Removed back and next buttons, updated heading, change ISO date format to day date

<img width="1552" alt="CleanShot 2022-08-04 at 20 14 33@2x" src="https://user-images.githubusercontent.com/39948231/182823272-dff61860-8b5c-4c6c-8326-c601813504d7.png">
